### PR TITLE
`PDBContainer` update

### DIFF
--- a/dataCAT/create_database.py
+++ b/dataCAT/create_database.py
@@ -187,7 +187,9 @@ def create_hdf5(path, name='structures.hdf5'):  # noqa: E302
 
             # Create a new group if it does not exist yet
             if grp_name not in f:
-                group = PDBContainer.create_hdf5_group(f, grp_name, IDX_DTYPE[grp_name], **kwargs)
+                group = PDBContainer.create_hdf5_group(
+                    f, grp_name, index_dtype=IDX_DTYPE[grp_name], **kwargs
+                )
             else:
                 group = f[grp_name]
 

--- a/dataCAT/create_database.py
+++ b/dataCAT/create_database.py
@@ -197,7 +197,7 @@ def create_hdf5(path, name='structures.hdf5'):  # noqa: E302
             _update_index_dset(group, grp_name, logger)
 
             if pdb is not None:
-                pdb.to_hdf5(group, mode='append')
+                pdb.append_hdf5(group)
 
             _update_property_dsets(group, grp_name)
 

--- a/dataCAT/database.py
+++ b/dataCAT/database.py
@@ -486,7 +486,7 @@ class Database:
 
         names = ('atoms', 'bonds', 'atom_count', 'bond_count')
         message = f"datasets={[group[n].name for n in names]!r}; overwrite=False"
-        update_hdf5_log(group['logger'], idx=ret.values, message=message)
+        update_hdf5_log(group['logger'], index=ret.values, message=message)
         df.update(ret, overwrite=True)
         if opt:
             df.loc[new_index, OPT] = True
@@ -500,11 +500,11 @@ class Database:
 
         index = mol_series.index.values.astype(dtype)
         pdb_old = PDBContainer.from_molecules(mol_series, index=index)
-        pdb_old.to_hdf5(group, mode='update', idx=old.values)
+        pdb_old.to_hdf5(group, mode='update', index=old.values)
 
         names = ('atoms', 'bonds', 'atom_count', 'bond_count')
         message = f"datasets={[group[n].name for n in names]!r}; overwrite=True"
-        update_hdf5_log(group['logger'], idx=old.values, message=message)
+        update_hdf5_log(group['logger'], index=old.values, message=message)
         if opt:
             df.loc[old.index, OPT] = True
 

--- a/dataCAT/database.py
+++ b/dataCAT/database.py
@@ -476,13 +476,13 @@ class Database:
         """Helper method for :meth:`update_hdf5` when :code:`overwrite = False`."""
         mol_series = df.loc[new_index, MOL]
 
-        index = cls._sanitize_multi_idx(new_index, dtype, database)
-        pdb_new = PDBContainer.from_molecules(mol_series, index=index)
-        pdb_new.append_hdf5(group)
-
-        j = len(group['atoms'])
-        i = j - len(mol_series)
+        i = len(group['atoms'])
+        j = i + len(mol_series)
         ret = pd.Series(np.arange(i, j), index=new_index, name=HDF5_INDEX)
+
+        scale = cls._sanitize_multi_idx(new_index, dtype, database)
+        pdb_new = PDBContainer.from_molecules(mol_series, scale=scale)
+        pdb_new.to_hdf5(group, index=np.s_[i:j], update_scale=not opt)
 
         names = ('atoms', 'bonds', 'atom_count', 'bond_count')
         message = f"datasets={[group[n].name for n in names]!r}; overwrite=False"
@@ -498,9 +498,9 @@ class Database:
         """Helper method for :meth:`update_hdf5` when :code:`overwrite = True`."""
         mol_series = df.loc[old.index, MOL]
 
-        index = mol_series.index.values.astype(dtype)
-        pdb_old = PDBContainer.from_molecules(mol_series, index=index)
-        pdb_old.update_hdf5(group, index=old.values)
+        scale = mol_series.index.values.astype(dtype)
+        pdb_old = PDBContainer.from_molecules(mol_series, scale=scale)
+        pdb_old.to_hdf5(group, index=old.values)
 
         names = ('atoms', 'bonds', 'atom_count', 'bond_count')
         message = f"datasets={[group[n].name for n in names]!r}; overwrite=True"

--- a/dataCAT/database.py
+++ b/dataCAT/database.py
@@ -478,7 +478,7 @@ class Database:
 
         index = cls._sanitize_multi_idx(new_index, dtype, database)
         pdb_new = PDBContainer.from_molecules(mol_series, index=index)
-        pdb_new.to_hdf5(group, mode='append')
+        pdb_new.append_hdf5(group)
 
         j = len(group['atoms'])
         i = j - len(mol_series)
@@ -500,7 +500,7 @@ class Database:
 
         index = mol_series.index.values.astype(dtype)
         pdb_old = PDBContainer.from_molecules(mol_series, index=index)
-        pdb_old.to_hdf5(group, mode='update', index=old.values)
+        pdb_old.update_hdf5(group, index=old.values)
 
         names = ('atoms', 'bonds', 'atom_count', 'bond_count')
         message = f"datasets={[group[n].name for n in names]!r}; overwrite=True"

--- a/dataCAT/functions.py
+++ b/dataCAT/functions.py
@@ -372,7 +372,7 @@ def _set_index(cls: Type[PDBContainer], group: h5py.Group,
     scale = group.create_dataset('index', shape=(length,), maxshape=(None,), dtype=dtype, **kwargs)
     scale.make_scale('index')
 
-    iterator = (group[k] for k in cls.keys() if k != 'index')
+    iterator = (group[k] for k in cls.keys() if k != 'scale')
     for dset in iterator:
         dset.dims[0].label = 'index'
         dset.dims[0].attach_scale(scale)

--- a/dataCAT/hdf5_log.py
+++ b/dataCAT/hdf5_log.py
@@ -206,7 +206,7 @@ def create_hdf5_log(file: h5py.Group,
     return grp
 
 
-def update_hdf5_log(group: h5py.Group, idx: ArrayLike,
+def update_hdf5_log(group: h5py.Group, index: ArrayLike,
                     message: Optional[str] = None,
                     version_values: Sequence[Tuple[int, int, int]] = _VERSION) -> None:
     r"""Add a new entry to the hdf5 logger in **file**.
@@ -239,7 +239,7 @@ def update_hdf5_log(group: h5py.Group, idx: ArrayLike,
         ...     date_before = group['date'][n]
         ...     index_before = group['index'][n]
         ...
-        ...     update_hdf5_log(group, idx=[0, 1, 2, 3], message='append')
+        ...     update_hdf5_log(group, index=[0, 1, 2, 3], message='append')
         ...     date_after = group['date'][n]
         ...     index_after = group['index'][n]
 
@@ -285,24 +285,24 @@ def update_hdf5_log(group: h5py.Group, idx: ArrayLike,
             group['message'].resize(n_max, axis=0)
 
     # Parse the passed **idx**
-    index = np.array(idx, ndmin=1, copy=False)
-    generic = index.dtype.type
-    if index.ndim > 1:
-        raise ValueError("The dimensionality of 'idx' should be <= 1; "
-                         f"observed dimensionality: {index.ndim!r}")
-    elif not index.ndim:
-        index = index.astype(INDEX_DTYPE)
+    idx = np.array(index, ndmin=1, copy=False)
+    generic = idx.dtype.type
+    if idx.ndim > 1:
+        raise ValueError("The dimensionality of 'index' should be <= 1; "
+                         f"observed dimensionality: {idx.ndim!r}")
+    elif not idx.ndim:
+        idx = idx.astype(INDEX_DTYPE)
 
     if issubclass(generic, np.bool_):
-        index, *_ = index.nonzero()
+        idx, *_ = idx.nonzero()
     elif not issubclass(generic, np.integer):
         raise TypeError("'idx' expected an integer or boolean array; "
-                        f"observed dtype: {index.dtype!r}")
+                        f"observed dtype: {idx.dtype!r}")
 
     # Update the datasets
     group['date'][n] = _get_now()
     group['version'][n] = version_values
-    group['index'][n] = index
+    group['index'][n] = idx
     if message is not None:
         group['message'][n] = message
 

--- a/dataCAT/pdb_array.py
+++ b/dataCAT/pdb_array.py
@@ -404,10 +404,10 @@ class PDBContainer:
         bond_count : :class:`numpy.ndarray[int32]<numpy.ndarray>`, shape :math:`(n,)`
             An ndarray for keeping track of the number of bonds in each molecule in **bonds**.
             See :attr:`PDBContainer.bond_count`.
-        index : :class:`numpy.recarray`, shape :math:`(n,)`, optional
+        scale : :class:`numpy.recarray`, shape :math:`(n,)`, optional
             A recarray representing an index.
             If :data:`None`, use a simple numerical index (*i.e.* :func:`numpy.arange`).
-            See :attr:`PDBContainer.index`.
+            See :attr:`PDBContainer.scale`.
 
         Keyword Arguments
         -----------------
@@ -1288,7 +1288,7 @@ class PDBContainer:
         Returns
         -------
         :class:`PDBContainer`
-            A new instance by intersecting :attr:`self.index<PDBContainer.scale>` and **value**.
+            A new instance by intersecting :attr:`self.scale<PDBContainer.scale>` and **value**.
 
         See Also
         --------
@@ -1454,9 +1454,9 @@ class PDBContainer:
         return self.concatenate(ret)
 
     def _get_index(self: ST, value: Union[ST, ArrayLike]) -> Tuple[np.recarray, np.ndarray]:
-        """Parse and return the :attr:`~PDBContainer.index` of **self** and **value**."""
+        """Parse and return the :attr:`~PDBContainer.scale` of **self** and **value**."""
         cls = type(self)
-        index1 = self.scale
-        _index2 = value.scale if isinstance(value, cls) else value
-        index2 = np.asarray(_index2, dtype=index1.dtype)
-        return index1, index2
+        scale1 = self.scale
+        _scale2 = value.scale if isinstance(value, cls) else value
+        scale2 = np.asarray(_scale2, dtype=scale1.dtype)
+        return scale1, scale2

--- a/dataCAT/property_dset.py
+++ b/dataCAT/property_dset.py
@@ -179,14 +179,15 @@ def create_prop_dset(group: h5py.Group, name: str, dtype: DtypeLike = None,
 
     """
     scale_name = f'{name}_names'
-    index_name = group.attrs['index']
-    index = group.file[index_name]
+    index_ref = group.attrs['index']
+    index = group.file[index_ref]
+    index_name = index.name.rsplit('/', 1)[-1]
     n = len(index)
 
     # If no prop_names are specified
     if prop_names is None:
         dset = group.create_dataset(name, shape=(n,), maxshape=(None,), dtype=dtype, **kwargs)
-        dset.dims[0].label = 'index'
+        dset.dims[0].label = index_name
         dset.dims[0].attach_scale(index)
         return dset
 
@@ -210,7 +211,7 @@ def create_prop_dset(group: h5py.Group, name: str, dtype: DtypeLike = None,
     scale.make_scale(scale_name)
 
     # Set the dimensional scale
-    dset.dims[0].label = 'index'
+    dset.dims[0].label = index_name
     dset.dims[0].attach_scale(index)
     dset.dims[1].label = scale_name
     dset.dims[1].attach_scale(scale)
@@ -234,7 +235,7 @@ def _null_value(dtype_like: DtypeLike) -> np.generic:
 
 def _resize_prop_dset(dset: h5py.Dataset) -> None:
     """Ensure that **dset** is as long as its dimensional scale."""
-    scale = dset.dims[0]['index']
+    scale = dset.dims[0][0]
     n = len(scale)
     if n > len(dset):
         dset.resize(n, axis=0)
@@ -286,14 +287,14 @@ def validate_prop_group(group: h5py.Group) -> None:
     """  # noqa: E501
     assertion.isinstance(group, h5py.Group)
 
-    index_ref = group.attrs['index']
-    index = group.file[index_ref]
+    idx_ref = group.attrs['index']
+    idx = group.file[idx_ref]
 
-    iterator = ((k, v) for k, v in group.items() if k != 'index' and not k.endswith('_names'))
+    iterator = ((k, v) for k, v in group.items() if not k.endswith('_names'))
     for name, dset in iterator:
-        assertion.le(len(dset), len(index), message=f'{name!r} invalid dataset length')
+        assertion.le(len(dset), len(idx), message=f'{name!r} invalid dataset length')
         assertion.contains(dset.dims[0].keys(), 'index', message=f'{name!r} missing dataset scale')
-        assertion.eq(dset.dims[0]['index'], index, message=f'{name!r} invalid dataset scale')
+        assertion.eq(dset.dims[0]['index'], idx, message=f'{name!r} invalid dataset scale')
 
 
 def prop_to_dataframe(dset: h5py.Dataset, dtype: DtypeLike = None) -> pd.DataFrame:
@@ -344,7 +345,7 @@ def prop_to_dataframe(dset: h5py.Dataset, dtype: DtypeLike = None) -> pd.DataFra
     # Construct the columns
     if dset.ndim == 1:
         full_name = dset.name
-        name = full_name.rsplit('/', 1)[1]
+        name = full_name.rsplit('/', 1)[-1]
         columns = pd.Index([name])
 
     else:

--- a/dataCAT/property_dset.py
+++ b/dataCAT/property_dset.py
@@ -217,8 +217,10 @@ def create_prop_dset(group: h5py.Group, name: str, dtype: DtypeLike = None,
     return dset
 
 
-def _null_value(dtype: np.dtype) -> np.generic:
+def _null_value(dtype_like: DtypeLike) -> np.generic:
+    dtype = np.dtype(dtype_like)
     generic = dtype.type
+
     if issubclass(generic, (np.number, np.bool_)):  # Numerical scalars
         return generic(False)
     elif not issubclass(generic, np.void):  # Strings, bytes & datetime64

--- a/tests/test_backwards_compat.py
+++ b/tests/test_backwards_compat.py
@@ -78,4 +78,4 @@ def test_create_database_4() -> None:
 
     ref = np.rec.array(None, dtype=LIG_IDX_DTYPE, shape=(3,))
     ref[:] = b''
-    assertion.eq(pdb.index, ref, post_process=np.all)
+    assertion.eq(pdb.scale, ref, post_process=np.all)

--- a/tests/test_hdf5_log.py
+++ b/tests/test_hdf5_log.py
@@ -26,7 +26,7 @@ def test_update_hdf5_log1() -> None:
 
         i += group.attrs['n_step']
         group.attrs['n'] = 100
-        update_hdf5_log(group, idx=[0])
+        update_hdf5_log(group, index=[0])
 
         n1 = group.attrs['n']
         assertion.eq(n1, 101)
@@ -49,7 +49,7 @@ def test_update_hdf5_log2() -> None:
         assertion.truth(n0)
 
         group.attrs['n'] = 100
-        update_hdf5_log(group, idx=[0])
+        update_hdf5_log(group, index=[0])
         group_new = f['ligand/logger']
 
         n1 = group_new.attrs['n']

--- a/tests/test_pdb_container.py
+++ b/tests/test_pdb_container.py
@@ -87,12 +87,22 @@ def test_validate() -> None:
             PDB.from_hdf5(group)
         except AssertionError as ex:
             assertion.isinstance(ex.__context__, KeyError)
-            group.create_dataset('atoms', data=[1])
+            dset = group.create_dataset('atoms', data=[1])
         else:
             raise AssertionError("Failed to raise an AssertionError")
 
         try:
-            PDB.to_hdf5(group)
+            PDB.append_hdf5(group)
+        except AssertionError as ex:
+            assertion.isinstance(ex.__context__, RuntimeError)
+            scale = group.create_dataset('index', data=[1], maxshape=(None,))
+            scale.make_scale('index')
+            dset.dims[0].attach_scale(scale)
+        else:
+            raise AssertionError("Failed to raise an AssertionError")
+
+        try:
+            PDB.append_hdf5(group)
         except AssertionError as ex:
             assertion.isinstance(ex.__context__, IndexError)
         else:

--- a/tests/test_pdb_container.py
+++ b/tests/test_pdb_container.py
@@ -3,6 +3,7 @@
 import os
 import copy
 import pickle
+from shutil import copyfile
 from pathlib import Path
 
 import h5py
@@ -11,13 +12,9 @@ from scm.plams import writepdb
 from assertionlib import assertion
 from nanoutils import delete_finally
 from dataCAT import PDBContainer
-from dataCAT.testing_utils import PDB
+from dataCAT.testing_utils import PDB, HDF5_READ, HDF5_TMP
 
-PATH = Path('tests') / 'test_files'
-
-HDF5_PATH = PATH / 'database' / 'structures.hdf5'
-HDF5_FAIL = PATH / '.tmp.hdf5'
-PDB_OUTPUT = PATH / '.pdb_files'
+PDB_OUTPUT = Path('tests') / 'test_files' / '.pdb_files'
 
 
 def test_pickle() -> None:
@@ -77,10 +74,10 @@ def test_to_molecules() -> None:
         writepdb(mol, filename)
 
 
-@delete_finally(HDF5_FAIL)
+@delete_finally(HDF5_TMP)
 def test_validate() -> None:
     """Test :meth:`PDBContainer.validate_hdf5`."""
-    with h5py.File(HDF5_FAIL, 'a', libver='latest') as f:
+    with h5py.File(HDF5_TMP, 'a', libver='latest') as f:
         group = f.create_group('test')
 
         try:
@@ -92,7 +89,7 @@ def test_validate() -> None:
             raise AssertionError("Failed to raise an AssertionError")
 
         try:
-            PDB.append_hdf5(group)
+            PDB.to_hdf5(group, None)
         except AssertionError as ex:
             assertion.isinstance(ex.__context__, RuntimeError)
             scale = group.create_dataset('index', data=[1], maxshape=(None,))
@@ -102,8 +99,20 @@ def test_validate() -> None:
             raise AssertionError("Failed to raise an AssertionError")
 
         try:
-            PDB.append_hdf5(group)
+            PDB.to_hdf5(group, None)
         except AssertionError as ex:
             assertion.isinstance(ex.__context__, IndexError)
         else:
             raise AssertionError("Failed to raise an AssertionError")
+
+
+@delete_finally(HDF5_TMP)
+def test_index_other() -> None:
+    """Test :func:`dataCAT.update_hdf5_log`."""
+    copyfile(HDF5_READ, HDF5_TMP)
+
+    with h5py.File(HDF5_TMP, 'r+') as f:
+        scale = f['ligand/index']
+        group = PDBContainer.create_hdf5_group(f, 'test', scale=scale)
+        dset = group['atoms']
+        assertion.eq(scale, dset.dims[0]['index'])


### PR DESCRIPTION
* Use a fill value when creating property datasets.
* Moved a number of functions from `functions` to `PDBContainer` as methods.
* Made the `index` argument mandatory for `PDBContainer.to_hdf5()`.
* Renamed `PDBContainer.index` to `.scale`.
* Prefer `index` over `idx` as parameter name.
* Allow multiple `PDBContainer` groups to share a single index.