### PR TITLE
ENH: Expose the `index_to_pandas` function

### DIFF
--- a/dataCAT/__init__.py
+++ b/dataCAT/__init__.py
@@ -17,13 +17,38 @@ version_info = DATACAT_VERSION
 del VersionInfo
 
 from .df_proxy import DFProxy
-from .property_dset import (create_prop_group, create_prop_dset, update_prop_dset,
-                            validate_prop_group, prop_to_dataframe)
-from .hdf5_log import create_hdf5_log, update_hdf5_log, reset_hdf5_log, log_to_dataframe
+
+from .property_dset import (
+    create_prop_group,
+    create_prop_dset,
+    update_prop_dset,
+    validate_prop_group,
+    prop_to_dataframe,
+    index_to_pandas,
+)
+
+from .hdf5_log import (
+    create_hdf5_log,
+    update_hdf5_log,
+    reset_hdf5_log,
+    log_to_dataframe,
+)
+
 from .pdb_array import PDBContainer
-from .context_managers import OpenLig, OpenQD
+
+from .context_managers import (
+    OpenLig,
+    OpenQD,
+)
+
 from .database import Database
-from . import functions, testing_utils, dtype, create_database
+
+from . import (
+    functions,
+    testing_utils,
+    dtype,
+    create_database,
+)
 
 __author__ = 'B. F. van Beek'
 __email__ = 'b.f.van.beek@vu.nl'
@@ -36,7 +61,7 @@ __all__ = [
     'create_hdf5_log', 'update_hdf5_log', 'reset_hdf5_log',
 
     'create_prop_group', 'create_prop_dset', 'update_prop_dset',
-    'validate_prop_group', 'prop_to_dataframe',
+    'validate_prop_group', 'prop_to_dataframe', 'index_to_pandas',
 
     'DFProxy',
 


### PR DESCRIPTION
`index_to_pandas` is a new function for converting the `"index"` dataset into a pandas MultiIndex.

Examples
----------
``` python
>>> from dataCAT import index_to_pandas
>>> import h5py

>>> filename = str(...)

>>> with h5py.File(filename, "r") as f:
...     dset: h5py.Dataset = f["ligand"]["index"]
...     index_to_pandas(dset)
MultiIndex([('O=C=O', 'O1'),
            ('O=C=O', 'O3'),
            ( 'CCCO', 'O4')],
           names=['ligand', 'ligand anchor'])
```