### PR TITLE
DEP: Replace `pd.DataFrame.append` with `pd.concat`

### DIFF
--- a/dataCAT/functions.py
+++ b/dataCAT/functions.py
@@ -262,7 +262,7 @@ def even_index(df1: pd.DataFrame, df2: pd.DataFrame) -> pd.DataFrame:
     nan_row = get_nan_row(df1)
     idx = df2.index[~bool_ar]
     df_tmp = pd.DataFrame(len(idx) * [nan_row], index=idx, columns=df1.columns)
-    return df1.append(df_tmp, sort=True)
+    return pd.concat([df1, df_tmp], sort=True)
 
 
 def int_to_slice(int_like: SupportsIndex, seq_len: int) -> slice:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ ignore = W504 N806
 testpaths = dataCAT tests
 addopts = --tb=short --doctest-glob='*.py' --doctest-glob='*.rst' --cov=dataCAT --cov-report xml --cov-report term --cov-report html --doctest-modules
 markers = slow: A marker for slow tests.
+filterwarnings =
+    ignore::DeprecationWarning:numpy.distutils.*
 
 # Define `python setup.py build_sphinx`
 [build_sphinx]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,7 +4,6 @@ import sys
 import copy
 import shutil
 import pickle
-import warnings
 from types import MappingProxyType
 from os.path import join, abspath
 from pathlib import Path
@@ -12,6 +11,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 import pandas as pd
+import pytest
 
 from scm.plams import readpdb
 from nanoutils import delete_finally
@@ -220,10 +220,7 @@ def test_update_hdf5_settinga() -> None:
                 pass
 
 
+@pytest.mark.skipif(DB.mongodb is None, reason="MongoDB server not found")
 def test_update_mbongodb() -> None:
     """Test :meth:`~dataCAT.Database.update_mbongodb`."""
-    if DB.mongodb is None:
-        warnings.warn("MongoDB server not found; skipping test", category=RuntimeWarning)
-        return
-
     DB.update_mongodb('ligand')


### PR DESCRIPTION
The `append` method has been deprecated as of Pandas 1.4